### PR TITLE
requires_model_validation deprecated in Django 1.7

### DIFF
--- a/vinaigrette/management/commands/makemessages.py
+++ b/vinaigrette/management/commands/makemessages.py
@@ -45,7 +45,7 @@ class Command(django_makemessages.Command):
     )
     
     help = "Runs over the entire source tree of the current directory and pulls out all strings marked for translation. It creates (or updates) a message file in the conf/locale (in the django tree) or locale (for project and application) directory. Also includes strings from database fields handled by vinaigrette."
-    requires_model_validation = True
+    requires_system_checks = True
     
     def handle(self, *args, **options):
         if not options.get('avec-vinaigrette'):


### PR DESCRIPTION
Replaced with requires_system_checks, for details check: https://docs.djangoproject.com/en/1.7/releases/1.7/#django-core-management-basecommand