### PR TITLE
collecting full property string to include in .po

### DIFF
--- a/vinaigrette/__init__.py
+++ b/vinaigrette/__init__.py
@@ -12,20 +12,20 @@ VERSION = "0.4.0"
 
 class VinaigretteError(Exception):
     pass
-    
+
 _registry = {}
 
 DOUBLE_PERCENTAGE_RE = re.compile(u'%(?!\()')
 
 def _vinaigrette_pre_save(sender, instance, **kwargs):
     setattr(instance, '_vinaigrette_saving', True)
-    
+
 def _vinaigrette_post_save(sender, instance, **kwargs):
     delattr(instance, '_vinaigrette_saving')
 
-def register(model, fields, restrict_to=None, manager=None):
+def register(model, fields, restrict_to=None, manager=None, properties=None):
     """Tell vinaigrette which fields on a Django model should be translated.
-    
+
     Arguments:
     model -- The relevant model class
     fields -- A list or tuple of field names. e.g. ['name', 'nickname']
@@ -33,27 +33,30 @@ def register(model, fields, restrict_to=None, manager=None):
         of objects to collect translation strings from.
     manager -- Optional. A reference to a manager -- e.g. Person.objects -- to use
         when collecting translation strings.
-        
+    properties -- A dictionary of "read only" properties that are composed by more that one field e.g. {'full_name': ['first_name', 'last_name']}
+
     Note that both restrict_to and manager are only used when collecting translation
     strings. Gettext lookups will always be performed on relevant fields for all
     objects on registered models.
     """
-    
+
     global _registry
     _registry[model] = {
         'fields': fields,
         'restrict_to': restrict_to,
-        'manager': manager
+        'manager': manager,
+        'properties': properties,
     }
+
     for field in fields:
         setattr(model, field, VinaigretteDescriptor(field))
     model.untranslated = lambda self, fieldname: self.__dict__[fieldname]
-    
+
     pre_save.connect(_vinaigrette_pre_save, sender=model)
     post_save.connect(_vinaigrette_post_save, sender=model)
 
 class VinaigretteDescriptor(object):
-    
+
     def __init__(self, name):
         self.name = name
 

--- a/vinaigrette/management/commands/makemessages.py
+++ b/vinaigrette/management/commands/makemessages.py
@@ -84,7 +84,7 @@ class Command(django_makemessages.Command):
                 if properties:
                    fields += properties.keys()
                    for prop in properties.itervalues():
-                       query_fields |= set(prop)
+                       query_fields.update(prop)
 
                 manager = reg['manager'] if reg['manager'] else model._default_manager
                 qs = manager.filter(reg['restrict_to']) if reg['restrict_to'] else manager.all()

--- a/vinaigrette/management/commands/makemessages.py
+++ b/vinaigrette/management/commands/makemessages.py
@@ -69,22 +69,20 @@ class Command(django_makemessages.Command):
             if verbosity > 0:
                 self.stdout.write('Vinaigrette is processing database values...')
             
-            for model in sorted(vinaigrette._registry.keys(),
-              key=lambda m: m._meta.object_name):
+            for model in sorted(vinaigrette._registry.keys(), key=lambda m: m._meta.object_name):
                 strings_seen = set()
                 modelname = "%s.%s" % (model._meta.app_label, model._meta.object_name)
                 reg = vinaigrette._registry[model]
                 fields = reg['fields']
                 properties = reg['properties']
-                query_fields = []
+                # make query_fields a set to avoid duplicates
+                query_fields = set(fields)
                 if properties:
                    for prop in properties.itervalues():
-                       query_fields += prop
-                query_fields += fields
-                query_fields = set(query_fields)
+                       query_fields |= set(prop)
+
                 manager = reg['manager'] if reg['manager'] else model._default_manager
-                qs = manager.filter(reg['restrict_to']) if reg['restrict_to'] \
-                    else manager.all()
+                qs = manager.filter(reg['restrict_to']) if reg['restrict_to'] else manager.all()
 
                 for instance in qs.order_by('pk').only('pk', *query_fields):
                     # iterate over "single" fields

--- a/vinaigrette/management/commands/makemessages.py
+++ b/vinaigrette/management/commands/makemessages.py
@@ -72,7 +72,7 @@ class Command(django_makemessages.Command):
             for model in sorted(vinaigrette._registry.keys(),
               key=lambda m: m._meta.object_name):
                 strings_seen = set()
-                modelname = model._meta.object_name
+                modelname = "%s.%s" % (model._meta.app_label, model._meta.object_name)
                 reg = vinaigrette._registry[model]
                 fields = reg['fields']
                 properties = reg['properties']

--- a/vinaigrette/management/commands/makemessages.py
+++ b/vinaigrette/management/commands/makemessages.py
@@ -37,14 +37,14 @@ def _get_po_paths(locales=[]):
     return po_paths
 
 class Command(django_makemessages.Command):
-    
+
     option_list = django_makemessages.Command.option_list + (
         make_option('--no-vinaigrette', default=True, action='store_false', dest='avec-vinaigrette',
             help="Don't include strings from database fields handled by vinaigrette."),
         make_option('--keep-obsolete', default=False, action='store_true', dest='keep-obsolete',
             help="Don't obsolete strings no longer referenced in code or Viniagrette's fields.")
     )
-    
+
     help = "Runs over the entire source tree of the current directory and pulls out all strings marked for translation. It creates (or updates) a message file in the conf/locale (in the django tree) or locale (for project and application) directory. Also includes strings from database fields handled by vinaigrette."
     
     # requires_model_validation deprecated since Django 1.7, replaced by requires_system_checks
@@ -56,11 +56,11 @@ class Command(django_makemessages.Command):
     def handle(self, *args, **options):
         if not options.get('avec-vinaigrette'):
             return super(Command, self).handle(*args, **options)
-        
+
         verbosity = int(options.get('verbosity'))
         vinfilepath = 'vinaigrette-deleteme.py'
         sources = ['', '']
-        
+
         # Because Django makemessages isn't very extensible, we're writing a
         # fake Python file, calling makemessages, then deleting it after.
         vinfile = codecs.open(vinfilepath, 'w', encoding='utf8')
@@ -75,41 +75,61 @@ class Command(django_makemessages.Command):
                 modelname = model._meta.object_name
                 reg = vinaigrette._registry[model]
                 fields = reg['fields']
+                properties = reg['properties']
+                query_fields = []
+                if properties:
+                   for prop in properties.itervalues():
+                       query_fields += prop
+                query_fields += fields
+                query_fields = set(query_fields)
                 manager = reg['manager'] if reg['manager'] else model._default_manager
                 qs = manager.filter(reg['restrict_to']) if reg['restrict_to'] \
                     else manager.all()
-            
-                for instance in qs.order_by('pk').values('pk', *fields):
-                    # In the reference comment in the po file, use the object's primary
-                    # key as the line number, but only if it's an integer primary key
-                    idnum = instance.pop('pk')
-                    try:
-                        idnum = int(idnum)
-                    except (ValueError, TypeError):
-                        idnum = 0
-                    for (fieldname, val) in instance.items():
+
+                for instance in qs.order_by('pk').only('pk', *query_fields):
+                    # iterate over "single" fields
+                    for field in fields:
+                        # In the reference comment in the po file, use the object's primary
+                        # key as the line number, but only if it's an integer primary key
+                        try:
+                            idnum = int(instance.pk)
+                        except (ValueError, TypeError):
+                            idnum = 0
+                        val = getattr(instance, field)
                         if val and val not in strings_seen:
                             strings_seen.add(val)
-                            sources.append('%s/%s:%s' % (modelname, fieldname, idnum))
+                            sources.append('%s/%s:%s' % (modelname, field, idnum))
                             vinfile.write(
-                                'gettext(%r)\n' 
+                                'gettext(%r)\n'
                                 % val.replace('\r', '').replace('%', '%%')
                             )
+                    # iterate over properies if they exist
+                    if properties:
+                        for prop in properties.iterkeys():
+                            val = getattr(instance, prop)
+                            if val and val not in strings_seen:
+                                strings_seen.add(val)
+                                sources.append('%s/%s:%s' % (modelname, prop, idnum))
+                                vinfile.write(
+                                    'gettext(%r)\n'
+                                    % val.replace('\r', '').replace('%', '%%')
+                                )
+
         finally:
             vinfile.close()
-        
+
         try:
             super(Command, self).handle(*args, **options)
         finally:
             os.unlink(vinfilepath)
-        
+
         r_lineref = re.compile(r'%s:(\d+)' % re.escape(vinfilepath))
         def lineref_replace(match):
             try:
                 return sources[int(match.group(1))]
             except (IndexError, ValueError):
                 return match.group(0)
-        
+
         # The PO file has been generated. Now, swap out the line-number
         # references to our fake python file for more descriptive
         # references.
@@ -128,12 +148,12 @@ class Command(django_makemessages.Command):
                 locales = [locales]
 
             po_paths = _get_po_paths(locales)
-            
+
         if options.get('keep-obsolete'):
-            obsolete_warning = ['#. %s\n' % 
+            obsolete_warning = ['#. %s\n' %
                 ugettext('Obsolete translation kept alive with Viniagrette').encode('utf8'),
                 '#: obsolete:0\n']
-        
+
         for po_path in po_paths:
             po_file = open(po_path)
             new_contents = []
@@ -156,11 +176,11 @@ class Command(django_makemessages.Command):
                             new_contents.extend(obsolete_warning)
                         if line.startswith('#~ '):
                             line = re.sub(r'^#~ ', '', line)
-                    
+
                     new_contents.append(line)
                 lastline = line
             po_file.close()
-            
+
             # Perhaps this should be done a little more atomically w/ renames?
             po_file = open(po_path, 'w')
             for line in new_contents:


### PR DESCRIPTION
Hi, 

I have a project where I don't fully use django's ORM and I need to translate fields that are composed by more than one db field. Image that I need to translate someone's full name (firstname + lastname) instead of having both translated separately.

I define a propery in my model like this:
```
@property
def full_name(self):
    return u"%s %s" % (self.first_name, self.last_name)
```

I needed the "full_name" to be included in the .po file, so I added a 5th parameter to the register function which included that property and the needed db fields.

The makemessages add the "single" fields normally and add the property fields if they exist.