### PR TITLE
Fix translation context

### DIFF
--- a/vinaigrette/__init__.py
+++ b/vinaigrette/__init__.py
@@ -38,6 +38,9 @@ def register(model, fields, restrict_to=None, manager=None, properties=None, con
         when collecting translation strings.
     properties -- A dictionary of "read only" properties that are composed by more that one field
                   e.g. {'full_name': ['first_name', 'last_name']}
+    contexts -- A dictionary including any (pgettext) context that may need
+                to be applied to each field.
+                e.g. {'name': 'db category name', 'description': 'db detailed category description'}
 
     Note that both restrict_to and manager are only used when collecting translation
     strings. Gettext lookups will always be performed on relevant fields for all

--- a/vinaigrette/__init__.py
+++ b/vinaigrette/__init__.py
@@ -3,7 +3,7 @@
 import re
 
 from django.db.models.signals import pre_save, post_save
-from django.utils.translation import ugettext
+from django.utils.translation import ugettext, pgettext
 
 # TODO: Deprecated. Remove in next major version
 from .middleware import VinaigretteAdminLanguageMiddleware as VinaigrettteAdminLanguageMiddleware
@@ -82,8 +82,10 @@ class VinaigretteDescriptor(object):
         # We double over all the keys to mimic how {% trans %} works
         key = DOUBLE_PERCENTAGE_RE.sub(u'%%', key)
         if self.context:
-            return pgettext(self.context, key).replace('%%', '%')
-        return ugettext(key).replace('%%', '%')
+            text = pgettext(self.context, key)
+        else:
+            text = ugettext(key)
+        return text.replace('%%', '%')
 
     def __set__(self, obj, value):
         obj.__dict__[self.name] = value


### PR DESCRIPTION
Related to #30 

- Add missing pgettext import
- Add new parametre docstring
- DRYer return


Turns out the previous version wasn't quite working. Things seem to work fine with the changes below.

Manually tested with code similar to:
```python
translated_fields = ('name', 'description')

vinaigrette.register(
    SomeModel,
    translated_fields,
    contexts={_f: f"{model._meta.label}.{_f}" for _f in translated_fields},
)
```

which generates po entries like:
```
#: vinaigrette-deleteme.py:1
msgctxt "my_app.SomeModel.name"
msgid "Foo"
msgstr ""

#: vinaigrette-deleteme.py:2
msgctxt "my_app.SomeModel.description"
msgid "Bar"
msgstr ""
```