### PR TITLE
Making makemessages independent from a compiled messages file

### DIFF
--- a/vinaigrette/management/commands/makemessages.py
+++ b/vinaigrette/management/commands/makemessages.py
@@ -98,7 +98,10 @@ class Command(django_makemessages.Command):
                     for field in fields:
                         # In the reference comment in the po file, use the object's primary
                         # key as the line number, but only if it's an integer primary key
-                        val = getattr(instance, field)
+
+                        # Do not try to translate an already translated string
+                        # but its untranslated version.
+                        val = instance.untranslated(field)
 
                         context = contexts.get(field, None)
                         if val and val not in strings_seen:

--- a/vinaigrette/tests/test_makemessages.py
+++ b/vinaigrette/tests/test_makemessages.py
@@ -3,14 +3,28 @@ import os
 
 from django.core import management
 from django.test import TestCase
+from django.utils import translation
 
 
 class TestVinaigretteMakemessages(TestCase):
     def setUp(self):
         self.popath = 'locale/fr/LC_MESSAGES/django.po'
+        self.mopath = 'locale/fr/LC_MESSAGES/django.mo'
+        self.popathen = 'locale/en/LC_MESSAGES/django.po'
+        self.mopathen = 'locale/en/LC_MESSAGES/django.mo'
 
     def tearDown(self):
-        os.remove(self.popath)
+        if os.path.exists(self.popath):
+            os.remove(self.popath)
+
+        if os.path.exists(self.mopath):
+            os.remove(self.mopath)
+
+        if os.path.exists(self.popathen):
+            os.remove(self.popathen)
+
+        if os.path.exists(self.mopathen):
+            os.remove(self.mopathen)
 
     def test_happy_path(self):
         management.call_command('makemessages', locale=('fr',))
@@ -22,3 +36,54 @@ class TestVinaigretteMakemessages(TestCase):
         }
         actual = {poentry.msgid: poentry.occurrences for poentry in pofile}
         self.assertDictContainsSubset(expected, actual)
+
+    def test_same_result_after_compilemessages(self):
+        """
+        Ensures that makemessages is not affected by a current compiled message
+        file.
+        """
+        # makemessages without translations being active
+        with translation.override(None):
+            management.call_command('makemessages', locale=('en',))
+
+        if os.path.exists(self.mopathen):
+            os.remove(self.mopathen)
+
+        # Fill some translations
+        pofileen = polib.pofile(self.popathen)
+
+        for entry in pofileen:
+            if entry.msgid == u'Vinaigrette':
+                entry.msgstr = u'blub'
+
+        pofileen.save(self.popathen)
+
+        # compilemessages
+        management.call_command('compilemessages', locale=('en',))
+
+        # Reload the catalog (clear catalog, then re-activate; rather hacky).
+        translation.trans_real.gettext_module._translations.clear()
+        translation.trans_real._translations.clear()
+        translation._trans._translations.clear()
+        translation._trans.catalog()._catalog.clear()
+        translation.activate('en')
+
+        # makemessages with translations being active
+        management.call_command('makemessages', locale=('en',))
+
+        # Did it work?
+        expected = {
+            u'Vinaigrette': ('blub', [(u'dressings.Dressing/name', u'1')]),
+            u'Ranch': ('', [(u'dressings.Dressing/name', u'2')]),
+            u'Thousand Island': ('', [(u'dressings.Dressing/name', u'3')]),
+        }
+
+        pofileen2 = polib.pofile(self.popathen)
+        actual = {}
+
+        for poentry in pofileen2:
+            if not poentry.obsolete:
+                actual[poentry.msgid] = (poentry.msgstr, poentry.occurrences)
+
+        for k, v in expected.items():
+            self.assertEqual(v, actual.get(k, None))


### PR DESCRIPTION
A usual workflow may be to create a message file using manage.py makemessages. Vinaigrette will infere msgids based on registered database tables, which works great. The next step is usually to provide translations represented by msgstrs in the message file. Then one may compile the file using manage.py compilemessages. So far all right.

However when one recreates the messages file later on, i.e. because one added content to a website and runs makemessage, vinaigrette will now read the translated content from the database because the compiled message file allows that. Hence, the msgids will be the translated strings and not the data actually present in the DB.

With this small PR I tried to make the behavior of makemessages independent of existing compiled message files by disabling translation when reading the values from the DB. This ensures that the msgids are always the values actually stored in the database.

Moreover I've added a small test to ensure this behavior, however it is not self-consistent as it needs to be run twice to get a representative result. This appears to be because for enabling translation based on a compiled message file one may need to restart the interpreter. - However I think this may be OK.

It would be great if anyone interested could have a look at this PR and if you like it maybe merge it.
Any comment welcome!