### PR TITLE
Exclude test_project/ and */tests/ from pip package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def yield_long_description_files():
 setup(
     name="django-vinaigrette",
     version="2.0.1",
-    packages=find_packages(),
+    packages=find_packages(exclude=["test_project*", "*.tests"]),
     description=__doc__,
     long_description='\n\n'.join(yield_long_description_files()),
     author="Ecometrica Ltd",


### PR DESCRIPTION
The `test_project/` package gets installed as part of django-vinaigrette's latest version and I happen to have another `test_project/` locally in my git checkout. 

The `test_project/` that gets installed under site-packages confuses my test setup due to it being imported first and because there's a code snippet which isn't compatible with Django 4. Namely `from django.conf.urls import url`.
Logs: https://github.com/kiwitcms/github-app/runs/7357182169?check_suite_focus=true

This PR excludes everything which is related to testing from the actual pip package. 

Please consider cutting a new version. 